### PR TITLE
aaiello/zeta-306-fix-smart-contracts-sast-results

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,7 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", "0.8.9"],
+    "compiler-version": ["error", "0.8.7"],
     "func-visibility": ["warn", { "ignoreConstructors": true }],
     "reason-string": ["warn", { "maxLength": 80 }],
     "no-empty-blocks": "off",

--- a/packages/example-contracts/contracts/cross-chain-counter/CrossChainCounter.sol
+++ b/packages/example-contracts/contracts/cross-chain-counter/CrossChainCounter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@zetachain/protocol-contracts/contracts/ZetaInterfaces.sol";

--- a/packages/example-contracts/contracts/cross-chain-counter/test/CounterZetaConnectorMock.sol
+++ b/packages/example-contracts/contracts/cross-chain-counter/test/CounterZetaConnectorMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@zetachain/protocol-contracts/contracts/ZetaInterfaces.sol";
 

--- a/packages/example-contracts/contracts/cross-chain-message/CrossChainMessage.sol
+++ b/packages/example-contracts/contracts/cross-chain-message/CrossChainMessage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@zetachain/protocol-contracts/contracts/ZetaInterfaces.sol";

--- a/packages/example-contracts/contracts/cross-chain-warriors/CrossChainWarriors.sol
+++ b/packages/example-contracts/contracts/cross-chain-warriors/CrossChainWarriors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/packages/example-contracts/contracts/cross-chain-warriors/test/CrossChainWarriorsMock.sol
+++ b/packages/example-contracts/contracts/cross-chain-warriors/test/CrossChainWarriorsMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "../CrossChainWarriors.sol";
 

--- a/packages/example-contracts/contracts/cross-chain-warriors/test/CrossChainWarriorsZetaConnectorMock.sol
+++ b/packages/example-contracts/contracts/cross-chain-warriors/test/CrossChainWarriorsZetaConnectorMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@zetachain/protocol-contracts/contracts/ZetaInterfaces.sol";
 

--- a/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwap.base.sol
+++ b/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwap.base.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
 import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";

--- a/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwap.bsc.sol
+++ b/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwap.bsc.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@zetachain/protocol-contracts/contracts/ZetaInterfaces.sol";
 import "@zetachain/protocol-contracts/contracts/ZetaReceiver.sol";

--- a/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwap.eth.sol
+++ b/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwap.eth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@zetachain/protocol-contracts/contracts/ZetaInterfaces.sol";
 

--- a/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwapErrors.sol
+++ b/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwapErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 interface MultiChainSwapErrors {
     error ErrorTransferringTokens(address token);

--- a/packages/example-contracts/contracts/multi-chain-swap/test/MultiChainSwapZetaConnector.sol
+++ b/packages/example-contracts/contracts/multi-chain-swap/test/MultiChainSwapZetaConnector.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@zetachain/protocol-contracts/contracts/ZetaInterfaces.sol";
 

--- a/packages/example-contracts/contracts/multi-chain-value/MultiChainValue.sol
+++ b/packages/example-contracts/contracts/multi-chain-value/MultiChainValue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@zetachain/protocol-contracts/contracts/ZetaEth.sol";

--- a/packages/example-contracts/contracts/multi-chain-value/test/MultiChainValueMock.sol
+++ b/packages/example-contracts/contracts/multi-chain-value/test/MultiChainValueMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "../MultiChainValue.sol";
 

--- a/packages/example-contracts/contracts/multi-chain-value/test/ZetaConnectorMock.sol
+++ b/packages/example-contracts/contracts/multi-chain-value/test/ZetaConnectorMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@zetachain/protocol-contracts/contracts/ZetaInterfaces.sol";
 

--- a/packages/example-contracts/contracts/shared/ZetaEthMock.sol
+++ b/packages/example-contracts/contracts/shared/ZetaEthMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/packages/example-contracts/hardhat.config.ts
+++ b/packages/example-contracts/hardhat.config.ts
@@ -15,7 +15,7 @@ const PRIVATE_KEYS = process.env.PRIVATE_KEY !== undefined ? [`0x${process.env.P
 
 const config: HardhatUserConfig = {
   solidity: {
-    compilers: [{ version: "0.6.6" /** For uniswap v2 */ }, { version: "0.8.9" }],
+    compilers: [{ version: "0.6.6" /** For uniswap v2 */ }, { version: "0.8.7" }],
     settings: {
       /**
        * @see {@link https://smock.readthedocs.io/en/latest/getting-started.html}

--- a/packages/protocol-contracts/contracts/ZetaConnector.eth.sol
+++ b/packages/protocol-contracts/contracts/ZetaConnector.eth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -8,18 +8,18 @@ import "./ZetaInterfaces.sol";
 
 contract ZetaConnectorEth is ZetaConnectorBase {
     constructor(
-        address _zetaTokenAddress,
-        address _tssAddress,
-        address _tssAddressUpdater
-    ) ZetaConnectorBase(_zetaTokenAddress, _tssAddress, _tssAddressUpdater) {}
+        address zetaTokenAddress_,
+        address tssAddress_,
+        address tssAddressUpdater_
+    ) ZetaConnectorBase(zetaTokenAddress_, tssAddress_, tssAddressUpdater_) {}
 
-    function getLockedAmount() public view returns (uint256) {
+    function getLockedAmount() external view returns (uint256) {
         return IERC20(zetaToken).balanceOf(address(this));
     }
 
     function send(ZetaInterfaces.SendInput calldata input) external override whenNotPaused {
         bool success = IERC20(zetaToken).transferFrom(msg.sender, address(this), input.zetaAmount);
-        require(success == true, "ZetaConnector: error transferring Zeta");
+        require(success, "ZetaConnector: error transferring Zeta");
 
         emit ZetaSent(
             msg.sender,
@@ -41,7 +41,7 @@ contract ZetaConnectorEth is ZetaConnectorBase {
         bytes32 internalSendHash
     ) external override whenNotPaused onlyTssAddress {
         bool success = IERC20(zetaToken).transfer(destinationAddress, zetaAmount);
-        require(success == true, "ZetaConnector: error transferring Zeta");
+        require(success, "ZetaConnector: error transferring Zeta");
 
         if (message.length > 0) {
             ZetaReceiver(destinationAddress).onZetaMessage(
@@ -69,7 +69,7 @@ contract ZetaConnectorEth is ZetaConnectorBase {
         bytes32 internalSendHash
     ) external override whenNotPaused onlyTssAddress {
         bool success = IERC20(zetaToken).transfer(originSenderAddress, zetaAmount);
-        require(success == true, "ZetaConnector: error transferring Zeta");
+        require(success, "ZetaConnector: error transferring Zeta");
 
         if (message.length > 0) {
             ZetaReceiver(originSenderAddress).onZetaRevert(

--- a/packages/protocol-contracts/contracts/ZetaConnector.non-eth.sol
+++ b/packages/protocol-contracts/contracts/ZetaConnector.non-eth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -18,12 +18,12 @@ interface ZetaToken is IERC20 {
 
 contract ZetaConnectorNonEth is ZetaConnectorBase {
     constructor(
-        address _zetaTokenAddress,
-        address _tssAddress,
-        address _tssAddressUpdater
-    ) ZetaConnectorBase(_zetaTokenAddress, _tssAddress, _tssAddressUpdater) {}
+        address zetaTokenAddress_,
+        address tssAddress_,
+        address tssAddressUpdater_
+    ) ZetaConnectorBase(zetaTokenAddress_, tssAddress_, tssAddressUpdater_) {}
 
-    function getLockedAmount() public view returns (uint256) {
+    function getLockedAmount() external view returns (uint256) {
         return ZetaToken(zetaToken).balanceOf(address(this));
     }
 

--- a/packages/protocol-contracts/contracts/ZetaConnectorErrors.sol
+++ b/packages/protocol-contracts/contracts/ZetaConnectorErrors.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.7;
+
+interface ZetaConnectorErrors {
+    error AddressCantBeZero();
+}

--- a/packages/protocol-contracts/contracts/ZetaEth.sol
+++ b/packages/protocol-contracts/contracts/ZetaEth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/packages/protocol-contracts/contracts/ZetaInteractor.sol
+++ b/packages/protocol-contracts/contracts/ZetaInteractor.sol
@@ -42,7 +42,7 @@ abstract contract ZetaInteractor is Ownable, ZetaInteractorErrors {
         if (msg.sender != address(connector)) revert InvalidCaller(msg.sender);
     }
 
-    // @dev: it's not use in this contract because it's a tool for inherit contracts
+    /// @dev: useful for contracts that inherit from this one
     function isValidChainId(uint256 chainId) internal view returns (bool) {
         return (keccak256(interactorsByChainId[chainId]) != keccak256(new bytes(0)));
     }

--- a/packages/protocol-contracts/contracts/ZetaInteractor.sol
+++ b/packages/protocol-contracts/contracts/ZetaInteractor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -42,6 +42,7 @@ abstract contract ZetaInteractor is Ownable, ZetaInteractorErrors {
         if (msg.sender != address(connector)) revert InvalidCaller(msg.sender);
     }
 
+    // @dev: it's not use in this contract because it's a tool for inherit contracts
     function isValidChainId(uint256 chainId) internal view returns (bool) {
         return (keccak256(interactorsByChainId[chainId]) != keccak256(new bytes(0)));
     }

--- a/packages/protocol-contracts/contracts/ZetaInteractorErrors.sol
+++ b/packages/protocol-contracts/contracts/ZetaInteractorErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 interface ZetaInteractorErrors {
     error InvalidDestinationChainId();

--- a/packages/protocol-contracts/contracts/ZetaInterfaces.sol
+++ b/packages/protocol-contracts/contracts/ZetaInterfaces.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 interface ZetaInterfaces {
     /**

--- a/packages/protocol-contracts/contracts/ZetaNonEth.sol
+++ b/packages/protocol-contracts/contracts/ZetaNonEth.sol
@@ -3,7 +3,9 @@
 pragma solidity 0.8.7;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+
 import "./ZetaNonEthErrors.sol";
+
 
 contract ZetaNonEth is ERC20Burnable, ZetaNonEthErrors {
     /**

--- a/packages/protocol-contracts/contracts/ZetaNonEthErrors.sol
+++ b/packages/protocol-contracts/contracts/ZetaNonEthErrors.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.7;
+
+interface ZetaNonEthErrors {
+    error AddressCantBeZero();
+    error InvalidCaller(address tss, address caller);
+    error InvalidMinter(address caller);
+}

--- a/packages/protocol-contracts/contracts/ZetaReceiver.sol
+++ b/packages/protocol-contracts/contracts/ZetaReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "./ZetaInterfaces.sol";
 

--- a/packages/protocol-contracts/contracts/testing/ZetaInteractorMock.sol
+++ b/packages/protocol-contracts/contracts/testing/ZetaInteractorMock.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "../ZetaInteractor.sol";
 
 contract ZetaInteractorMock is ZetaInteractor {
     constructor(address zetaConnectorAddress) ZetaInteractor(zetaConnectorAddress) {}
 
-    function onZetaMessage(ZetaInterfaces.ZetaMessage calldata zetaMessage) public isValidMessageCall(zetaMessage) {}
+    function onZetaMessage(ZetaInterfaces.ZetaMessage calldata zetaMessage) external isValidMessageCall(zetaMessage) {}
 
-    function onZetaRevert(ZetaInterfaces.ZetaRevert calldata zetaRevert) public isValidRevertCall(zetaRevert) {}
+    function onZetaRevert(ZetaInterfaces.ZetaRevert calldata zetaRevert) external isValidRevertCall(zetaRevert) {}
 }

--- a/packages/protocol-contracts/contracts/testing/ZetaReceiverMock.sol
+++ b/packages/protocol-contracts/contracts/testing/ZetaReceiverMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.9;
+pragma solidity 0.8.7;
 
 import "../ZetaReceiver.sol";
 

--- a/packages/protocol-contracts/hardhat.config.ts
+++ b/packages/protocol-contracts/hardhat.config.ts
@@ -13,7 +13,7 @@ const PRIVATE_KEYS =
   process.env.PRIVATE_KEY !== undefined ? [`0x${process.env.PRIVATE_KEY}`, `0x${process.env.TSS_PRIVATE_KEY}`] : [];
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.9",
+  solidity: "0.8.7",
   etherscan: {
     ...getHardhatConfigScanners(),
   },

--- a/packages/protocol-contracts/test/ZetaConnector.spec.ts
+++ b/packages/protocol-contracts/test/ZetaConnector.spec.ts
@@ -538,7 +538,7 @@ describe("ZetaConnector tests", () => {
               new ethers.utils.AbiCoder().encode(["string"], ["hello"]),
               "0x0000000000000000000000000000000000000000000000000000000000000000"
             )
-        ).to.revertedWith("ZetaNonEth: only TSSAddress or connectorAddress can mint");
+        ).to.revertedWith(`InvalidMinter("0xF6a8aD553b265405526030c2102fda2bDcdDC177")`);
       });
 
       it("Should mint on the receiver address", async () => {


### PR DESCRIPTION
Erros ignored:

Reentrancy in ZetaConnectorEth.onReceive(bytes,uint256,address,uint256,bytes,bytes32)
- Can only be called by TSS

Reentrancy in ZetaConnectorNonEth.onReceive(bytes,uint256,address,uint256,bytes,bytes32) 
- Can only be called by TSS

Reentrancy in ZetaConnectorEth.onRevert(address,uint256,bytes,uint256,uint256,bytes,bytes32) 
- Can only be called by TSS

Reentrancy in ZetaConnectorNonEth.onRevert(address,uint256,bytes,uint256,uint256,bytes,bytes32) 
- Can only be called by TSS

Reentrancy in ZetaConnectorEth.send(ZetaInterfaces.SendInput) 
- Can only be called by TSS

Reentrancy in ZetaConnectorNonEth.send(ZetaInterfaces.SendInput)
- Can only be called by TSS

Different versions of Solidity are used:
        - Version used: ['0.8.7', '^0.8.0']
- Are OZ vs Zeta. Zeta contracts are all 0.8.7

ZetaInteractor.isValidChainId(uint256) (contracts/ZetaInteractor.sol#46-48) is never used and should be removed


ZetaNonEth (contracts/ZetaNonEth.sol#8-68) should inherit from ZetaToken
- We want it different

ZetaInteractorMock (contracts/testing/ZetaInteractorMock.sol#6-12) should inherit from ZetaReceiver 
- Just mock

Parameter ZetaNonEth.updateTSSAndConnectorAddresses(address,address)._tss  is not in mixedCase
- We know it and we allow it

Parameter ZetaNonEth.updateTSSAndConnectorAddresses(address,address)._connectorAddress is not in mixedCase
- We know it and we allow it

Variable ZetaNonEth.TSSAddress is not in mixedCase
- We know it and we allow it

Variable ZetaNonEth.TSSAddressUpdater is not in mixedCase
- We know it and we allow it

Parameter ZetaReceiverMock.onZetaMessage(ZetaInterfaces.ZetaMessage)._zetaMessage  is not in mixedCase
- We know it and we allow it

Parameter ZetaReceiverMock.onZetaRevert(ZetaInterfaces.ZetaRevert)._zetaRevert is not in mixedCase
- We know it and we allow it


