### PR TITLE
Set initial package version to be able to import via git

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "zetachain",
   "license": "MIT",
+  "version": "0.1.0",
   "private": true,
   "workspaces": {
     "packages": [


### PR DESCRIPTION
Otherwise I get the error:

```
$ yarn add https://github.com/zeta-chain/zetachain.git
error Can't add "zetachain": invalid package version undefined.
```