### PR TITLE
Allow TSS to call updateTssAddress

### DIFF
--- a/packages/protocol-contracts/contracts/ZetaConnector.base.sol
+++ b/packages/protocol-contracts/contracts/ZetaConnector.base.sol
@@ -72,7 +72,8 @@ contract ZetaConnectorBase is ConnectorErrors, Pausable {
         _;
     }
 
-    function updateTssAddress(address tssAddress_) external onlyTssUpdater {
+    function updateTssAddress(address tssAddress_) external {
+        if (msg.sender != tssAddress && msg.sender != tssAddressUpdater) revert CallerIsNotTssOrUpdater(msg.sender);
         if (tssAddress_ == address(0)) revert InvalidAddress();
 
         tssAddress = tssAddress_;

--- a/packages/protocol-contracts/contracts/interfaces/ConnectorErrors.sol
+++ b/packages/protocol-contracts/contracts/interfaces/ConnectorErrors.sol
@@ -6,6 +6,8 @@ interface ConnectorErrors {
 
     error CallerIsNotTssUpdater(address caller);
 
+    error CallerIsNotTssOrUpdater(address caller);
+
     error InvalidAddress();
 
     error ZetaTransferError();

--- a/packages/protocol-contracts/test/ZetaConnector.spec.ts
+++ b/packages/protocol-contracts/test/ZetaConnector.spec.ts
@@ -92,16 +92,24 @@ describe("ZetaConnector tests", () => {
 
   describe("ZetaConnector.base", () => {
     describe("updateTssAddress", () => {
-      it("Should revert if the caller is not the TSS updater", async () => {
+      it("Should revert if the caller is not TSS or TSS updater", async () => {
         await expect(
           zetaConnectorBaseContract.connect(randomSigner).updateTssAddress(randomSigner.address)
-        ).to.revertedWith(`CallerIsNotTssUpdater("${randomSigner.address}")`);
+        ).to.revertedWith(`CallerIsNotTssOrUpdater("${randomSigner.address}")`);
       });
 
       it("Should revert if the new TSS address is invalid", async () => {
         await expect(
           zetaConnectorBaseContract.updateTssAddress("0x0000000000000000000000000000000000000000")
         ).to.revertedWith(`InvalidAddress()`);
+      });
+
+      it("Should change the TSS address if called by TSS", async () => {
+        await (await zetaConnectorBaseContract.connect(tssSigner).updateTssAddress(randomSigner.address)).wait();
+
+        const address = await zetaConnectorBaseContract.tssAddress();
+
+        expect(address).to.equal(randomSigner.address);
       });
 
       it("Should change the TSS address if called by TSS updater", async () => {


### PR DESCRIPTION
### Overview
Allows TSS to update itself.
This is useful to test the capability of TSS changing itself before tssUpdater renounces to its role.