### PR TITLE
Implement veridise audit suggestions

### DIFF
--- a/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwap.base.sol
+++ b/packages/example-contracts/contracts/multi-chain-swap/MultiChainSwap.base.sol
@@ -9,7 +9,7 @@ import "@zetachain/protocol-contracts/contracts/interfaces/ZetaInterfaces.sol";
 import "./MultiChainSwapErrors.sol";
 
 contract MultiChainSwapBase is ZetaInteractor, ZetaReceiver, MultiChainSwapErrors {
-    uint16 internal constant MAX_DEADLINE = 365;
+    uint16 internal constant MAX_DEADLINE = 200;
     bytes32 public constant CROSS_CHAIN_SWAP_MESSAGE = keccak256("CROSS_CHAIN_SWAP");
 
     address public uniswapV2RouterAddress;

--- a/packages/protocol-contracts/contracts/ZetaConnector.non-eth.sol
+++ b/packages/protocol-contracts/contracts/ZetaConnector.non-eth.sol
@@ -5,16 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "./ZetaConnector.base.sol";
 import "./interfaces/ZetaInterfaces.sol";
-
-interface ZetaToken is IERC20 {
-    function burnFrom(address account, uint256 amount) external;
-
-    function mint(
-        address mintee,
-        uint256 value,
-        bytes32 internalSendHash
-    ) external;
-}
+import "./Zeta.non-eth.sol";
 
 contract ZetaConnectorNonEth is ZetaConnectorBase {
     uint256 public maxSupply = 2**256 - 1;
@@ -27,7 +18,7 @@ contract ZetaConnectorNonEth is ZetaConnectorBase {
     ) ZetaConnectorBase(zetaTokenAddress_, tssAddress_, tssAddressUpdater_, pauserAddress_) {}
 
     function getLockedAmount() external view returns (uint256) {
-        return ZetaToken(zetaToken).balanceOf(address(this));
+        return ZetaNonEth(zetaToken).balanceOf(address(this));
     }
 
     function setMaxSupply(uint256 maxSupply_) external onlyTssAddress {
@@ -35,7 +26,7 @@ contract ZetaConnectorNonEth is ZetaConnectorBase {
     }
 
     function send(ZetaInterfaces.SendInput calldata input) external override whenNotPaused {
-        ZetaToken(zetaToken).burnFrom(msg.sender, input.zetaValueAndGas);
+        ZetaNonEth(zetaToken).burnFrom(msg.sender, input.zetaValueAndGas);
 
         emit ZetaSent(
             tx.origin,
@@ -57,8 +48,8 @@ contract ZetaConnectorNonEth is ZetaConnectorBase {
         bytes calldata message,
         bytes32 internalSendHash
     ) external override whenNotPaused onlyTssAddress {
-        if (zetaValueAndGas + ZetaToken(zetaToken).totalSupply() > maxSupply) revert ExceedsMaxSupply(maxSupply);
-        ZetaToken(zetaToken).mint(destinationAddress, zetaValueAndGas, internalSendHash);
+        if (zetaValueAndGas + ZetaNonEth(zetaToken).totalSupply() > maxSupply) revert ExceedsMaxSupply(maxSupply);
+        ZetaNonEth(zetaToken).mint(destinationAddress, zetaValueAndGas, internalSendHash);
 
         if (message.length > 0) {
             ZetaReceiver(destinationAddress).onZetaMessage(
@@ -91,8 +82,8 @@ contract ZetaConnectorNonEth is ZetaConnectorBase {
         bytes calldata message,
         bytes32 internalSendHash
     ) external override whenNotPaused onlyTssAddress {
-        if (zetaValueAndGas + ZetaToken(zetaToken).totalSupply() > maxSupply) revert ExceedsMaxSupply(maxSupply);
-        ZetaToken(zetaToken).mint(zetaTxSenderAddress, zetaValueAndGas, internalSendHash);
+        if (zetaValueAndGas + ZetaNonEth(zetaToken).totalSupply() > maxSupply) revert ExceedsMaxSupply(maxSupply);
+        ZetaNonEth(zetaToken).mint(zetaTxSenderAddress, zetaValueAndGas, internalSendHash);
 
         if (message.length > 0) {
             ZetaReceiver(zetaTxSenderAddress).onZetaRevert(

--- a/packages/protocol-contracts/contracts/ZetaInteractor.sol
+++ b/packages/protocol-contracts/contracts/ZetaInteractor.sol
@@ -7,6 +7,7 @@ import "./interfaces/ZetaInterfaces.sol";
 import "./interfaces/ZetaInteractorErrors.sol";
 
 abstract contract ZetaInteractor is Ownable, ZetaInteractorErrors {
+    bytes32 constant ZERO_BYTES = keccak256(new bytes(0));
     uint256 internal immutable currentChainId;
     ZetaConnector public connector;
 
@@ -46,7 +47,7 @@ abstract contract ZetaInteractor is Ownable, ZetaInteractorErrors {
      * @dev Useful for contracts that inherit from this one
      */
     function _isValidChainId(uint256 chainId) internal view returns (bool) {
-        return (keccak256(interactorsByChainId[chainId]) != keccak256(new bytes(0)));
+        return (keccak256(interactorsByChainId[chainId]) != ZERO_BYTES);
     }
 
     function setInteractorByChainId(uint256 destinationChainId, bytes calldata contractAddress) external onlyOwner {

--- a/packages/protocol-contracts/contracts/ZetaTokenConsumerUniV2.strategy.sol
+++ b/packages/protocol-contracts/contracts/ZetaTokenConsumerUniV2.strategy.sol
@@ -20,7 +20,7 @@ interface ZetaTokenConsumerUniV2Errors {
  * @dev Uniswap V2 strategy for ZetaTokenConsumer
  */
 contract ZetaTokenConsumerUniV2 is ZetaTokenConsumer, ZetaTokenConsumerUniV2Errors {
-    uint256 internal constant MAX_DEADLINE = 100;
+    uint256 internal constant MAX_DEADLINE = 200;
 
     address public uniswapV2RouterAddress;
     address internal immutable wETH;

--- a/packages/protocol-contracts/contracts/ZetaTokenConsumerUniV3.strategy.sol
+++ b/packages/protocol-contracts/contracts/ZetaTokenConsumerUniV3.strategy.sol
@@ -15,6 +15,8 @@ interface ZetaTokenConsumerUniV3Errors {
     error ErrorGettingToken();
 
     error ErrorSendingETH();
+
+    error RentrancyError();
 }
 
 interface WETH9 {
@@ -25,7 +27,7 @@ interface WETH9 {
  * @dev Uniswap V3 strategy for ZetaTokenConsumer
  */
 contract ZetaTokenConsumerUniV3 is ZetaTokenConsumer, ZetaTokenConsumerUniV3Errors {
-    uint256 internal constant MAX_DEADLINE = 100;
+    uint256 internal constant MAX_DEADLINE = 200;
 
     uint24 public immutable zetaPoolFee;
     uint24 public immutable tokenPoolFee;
@@ -35,6 +37,8 @@ contract ZetaTokenConsumerUniV3 is ZetaTokenConsumer, ZetaTokenConsumerUniV3Erro
 
     ISwapRouter public immutable uniswapV3Router;
     IQuoter public immutable quoter;
+
+    bool internal locked;
 
     constructor(
         address zetaToken_,
@@ -57,6 +61,13 @@ contract ZetaTokenConsumerUniV3 is ZetaTokenConsumer, ZetaTokenConsumerUniV3Erro
         WETH9Address = WETH9Address_;
         zetaPoolFee = zetaPoolFee_;
         tokenPoolFee = tokenPoolFee_;
+    }
+
+    modifier noReentrant() {
+        if (locked) revert RentrancyError();
+        locked = true;
+        _;
+        locked = false;
     }
 
     receive() external payable {}
@@ -143,10 +154,11 @@ contract ZetaTokenConsumerUniV3 is ZetaTokenConsumer, ZetaTokenConsumerUniV3Erro
 
         WETH9(WETH9Address).withdraw(amountOut);
 
+        emit ZetaExchangedForEth(zetaTokenAmount, amountOut);
+
         (bool sent, ) = destinationAddress.call{value: amountOut}("");
         if (!sent) revert ErrorSendingETH();
 
-        emit ZetaExchangedForEth(zetaTokenAmount, amountOut);
         return amountOut;
     }
 
@@ -155,7 +167,7 @@ contract ZetaTokenConsumerUniV3 is ZetaTokenConsumer, ZetaTokenConsumerUniV3Erro
         uint256 minAmountOut,
         address outputToken,
         uint256 zetaTokenAmount
-    ) external override returns (uint256) {
+    ) external override noReentrant returns (uint256) {
         if (destinationAddress == address(0) || outputToken == address(0)) revert InvalidAddress();
         if (zetaTokenAmount == 0) revert InputCantBeZero();
 


### PR DESCRIPTION
### Summary

- Fix possible event reordering via reentrancy in getZetaFromToken
- Fix possible event reordering via reentrancy in getEthFromZeta
- Include ZetaNonEth in ZetaConnector
- Allow Updating of MAX_DEADLINE for TokenConsumers: We decide to increase the value
- Save gas by replacing keccak(constant) with a constant