### PR TITLE
enabled gitguardian check

### DIFF
--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -1,0 +1,21 @@
+name: GitGuardian scan
+
+on: [push, pull_request]
+
+jobs:
+  scanning:
+    name: GitGuardian scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch all history so multiple commits can be scanned
+      - name: GitGuardian scan
+        uses: GitGuardian/ggshield-action@master
+        env:
+          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
+          GITHUB_PULL_BASE_SHA:  ${{ github.event.pull_request.base.sha }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}


### PR DESCRIPTION
Set to none blocking for now. Runs a scan to make sure no secrets are being committed using gitguardian.com

Anyone on the engineering team can access gitguardian.com using their ZetaChain email account. 