### PR TITLE
chore: adds a script command to compile TS

### DIFF
--- a/packages/addresses-tools/package.json
+++ b/packages/addresses-tools/package.json
@@ -9,7 +9,8 @@
   },
   "main": "src/index.ts",
   "scripts": {
-    "tsc:watch": "npx tsc --watch"
+    "tsc:watch": "npx tsc --watch",
+    "compile": "tsc"
   },
   "devDependencies": {
     "@zetachain/addresses": "workspace:^"

--- a/packages/addresses-tools/package.json
+++ b/packages/addresses-tools/package.json
@@ -2,7 +2,6 @@
   "name": "@zetachain/addresses-tools",
   "version": "0.0.1",
   "license": "MIT",
-  "private": true,
   "author": "zetachain",
   "publishConfig": {
     "access": "public",

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zetachain/addresses",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "author": "zetachain",
   "publishConfig": {

--- a/packages/zevm-example-contracts/package.json
+++ b/packages/zevm-example-contracts/package.json
@@ -2,7 +2,6 @@
   "name": "@zetachain/zevm-example-contracts",
   "version": "0.0.1",
   "license": "MIT",
-  "private": true,
   "author": "zetachain",
   "publishConfig": {
     "access": "public",
@@ -34,7 +33,6 @@
     "@zetachain/addresses": "workspace:^",
     "@zetachain/addresses-tools": "workspace:^",
     "@zetachain/interfaces": "workspace:^",
-    "@zetachain/protocol-contracts": "workspace:^",
     "@zetachain/zevm-protocol-contracts": "workspace:^",
     "ethers": "5.6.8"
   }

--- a/packages/zevm-protocol-contracts/package.json
+++ b/packages/zevm-protocol-contracts/package.json
@@ -2,7 +2,6 @@
   "name": "@zetachain/zevm-protocol-contracts",
   "version": "0.0.1",
   "license": "MIT",
-  "private": true,
   "author": "zetachain",
   "publishConfig": {
     "access": "public",
@@ -31,10 +30,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "4.7.3",
     "@uniswap/v2-periphery": "1.1.0-beta.0",
-    "@zetachain/addresses": "workspace:^",
     "@zetachain/addresses-tools": "workspace:^",
-    "@zetachain/interfaces": "workspace:^",
-    "@zetachain/protocol-contracts": "workspace:^",
     "ethers": "5.6.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2782,7 +2782,6 @@ __metadata:
     "@zetachain/addresses": "workspace:^"
     "@zetachain/addresses-tools": "workspace:^"
     "@zetachain/interfaces": "workspace:^"
-    "@zetachain/protocol-contracts": "workspace:^"
     "@zetachain/zevm-protocol-contracts": "workspace:^"
     ethers: 5.6.8
     hardhat-gas-reporter: ^1.0.8
@@ -2797,10 +2796,7 @@ __metadata:
   dependencies:
     "@openzeppelin/contracts": 4.7.3
     "@uniswap/v2-periphery": 1.1.0-beta.0
-    "@zetachain/addresses": "workspace:^"
     "@zetachain/addresses-tools": "workspace:^"
-    "@zetachain/interfaces": "workspace:^"
-    "@zetachain/protocol-contracts": "workspace:^"
     ethers: 5.6.8
     hardhat-gas-reporter: ^1.0.8
     solidity-coverage: ^0.7.20


### PR DESCRIPTION
Context: https://zetachain.slack.com/archives/C03MMRN0ZPW/p1681295878246589

```ts
import { HardhatUserConfig } from "hardhat/config";
import "@nomicfoundation/hardhat-toolbox";
import { getHardhatConfigNetworks } from "@zetachain/addresses-tools/src/networks";
import * as dotenv from "dotenv";

dotenv.config();
const PRIVATE_KEYS = [`0x${process.env.PRIVATE_KEY}`];

const config: HardhatUserConfig = {
  solidity: "0.8.18",
  networks: {
    ...getHardhatConfigNetworks(PRIVATE_KEYS),
  },
};

export default config;
```

It fails with:

```
/Users/fadeev/zetachain/hellozeta/node_modules/@zetachain/addresses-tools/src/networks.ts:1
import type { NetworksUserConfig } from "hardhat/types";
^^^^^^

SyntaxError: Cannot use import statement outside a module
```

To resolve this I've added a `compile` script in `addresses-tools`, so that when you run `yarn compile` from the root, it generates `addresses-tools/dist` directory, which contains files that I can then import from a standalone Hardhat config. This `dist` should be published on npm. Currently, only `src` [is published](https://www.npmjs.com/package/@zetachain/addresses-tools?activeTab=code).