### PR TITLE
chore: yarn script to compile TS

### DIFF
--- a/packages/addresses-tools/package.json
+++ b/packages/addresses-tools/package.json
@@ -9,7 +9,8 @@
   },
   "main": "src/index.ts",
   "scripts": {
-    "tsc:watch": "npx tsc --watch"
+    "tsc:watch": "npx tsc --watch",
+    "compile": "tsc"
   },
   "devDependencies": {
     "@zetachain/addresses": "workspace:^"


### PR DESCRIPTION
Context: https://zetachain.slack.com/archives/C03MMRN0ZPW/p1681295878246589

```ts
import { HardhatUserConfig } from "hardhat/config";
import "@nomicfoundation/hardhat-toolbox";
import { getHardhatConfigNetworks } from "@zetachain/addresses-tools/src/networks";
import * as dotenv from "dotenv";

dotenv.config();
const PRIVATE_KEYS = [`0x${process.env.PRIVATE_KEY}`];

const config: HardhatUserConfig = {
  solidity: "0.8.18",
  networks: {
    ...getHardhatConfigNetworks(PRIVATE_KEYS),
  },
};

export default config;
```

It fails with:

```
/Users/fadeev/zetachain/hellozeta/node_modules/@zetachain/addresses-tools/src/networks.ts:1
import type { NetworksUserConfig } from "hardhat/types";
^^^^^^

SyntaxError: Cannot use import statement outside a module
```

To resolve this I've added a `compile` script in `addresses-tools`, so that when you run `yarn compile` from the root, it generates `addresses-tools/dist` directory, which contains files that I can then import from a standalone Hardhat config. This `dist` should be published on npm. Currently, only `src` [is published](https://www.npmjs.com/package/@zetachain/addresses-tools?activeTab=code).