### PR TITLE
chore: compile TS before publishing

### DIFF
--- a/packages/addresses/.npmignore
+++ b/packages/addresses/.npmignore
@@ -22,3 +22,9 @@ test
 
 # git
 .git
+
+# Include the dist folder and other necessary files
+!dist/
+!README.md
+!LICENSE
+!package.json

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "tsc:watch": "npx tsc --watch",
-    "prepublishOnly": "vite build"
+    "prepublishOnly": "npx tsc"
   },
   "devDependencies": {
     "vite": "^3.1.0",


### PR DESCRIPTION
`dist` before:

```
addresses.helpers.d.ts
index.d.ts
zetachain-addresses.mjs
zetachain-addresses.umd.js
```

`dist` after:

```
addresses.athens.json
addresses.helpers.d.ts
addresses.helpers.js
addresses.mainnet.json
addresses.troy.json
index.d.ts
index.js
```

closes https://github.com/zeta-chain/zetachain/issues/87